### PR TITLE
feat: working dynamic linking on stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build
 /lean_packages/*
 !/lean_packages/manifest.json
+.lake/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ name = "some_rust_lib"
 version = "0.1.0"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": 7,
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "RustFFI",
+ "lakeDir": ".lake"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,23 +10,23 @@ lean_exe ffi where
 def ffiC := "ffi.c"
 def ffiO := "ffi.o"
 
-target importTarget (pkg : Package) : FilePath := do
-  let oFile := pkg.oleanDir / ffiO
+target importTarget (pkg : NPackage _package.name) : FilePath := do
+  let oFile := pkg.buildDir / ffiO
   let srcJob ← inputFile ffiC
   buildFileAfterDep oFile srcJob fun srcFile => do
     let flags := #["-I", (← getLeanIncludeDir).toString]
     compileO ffiC oFile srcFile flags
 
-extern_lib libffi (pkg : Package) := do
-  let name := nameToStaticLib "ffi"
+extern_lib libffi (pkg : NPackage _package.name) := do
+  let name := nameToSharedLib "ffi"
   let job ← fetch <| pkg.target ``importTarget
-  buildStaticLib (pkg.libDir / name) #[job]
+  buildLeanSharedLib (pkg.buildDir / name) #[job]
 
-extern_lib some_rust_lib (pkg : Package) := do
+extern_lib some_rust_lib (pkg : NPackage _package.name) := do
   proc { cmd := "cargo", args := #["build", "--release"], cwd := pkg.dir }
-  let name := nameToStaticLib "some_rust_lib"
+  let name := nameToSharedLib "some_rust_lib"
   let srcPath := pkg.dir / "target" / "release" / name
-  IO.FS.createDirAll pkg.libDir
-  let tgtPath := pkg.libDir / name
+  IO.FS.createDirAll pkg.buildDir
+  let tgtPath := pkg.buildDir / name
   IO.FS.writeBinFile tgtPath (← IO.FS.readBinFile srcPath)
   return (pure tgtPath)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-12-08
+leanprover/lean4:stable


### PR DESCRIPTION
Upgrades to use `leanprover/lean4:stable`.

However also uses dynamic linking rather than static linking so this may be something to put on another branch and link to from the readme in https://github.com/lurk-lab/RustFFI.lean/pull/4/files if it is merged to main.